### PR TITLE
Reset physical bone transform

### DIFF
--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1660,10 +1660,13 @@ local NETFUNC = {
 		if not IsValid(ent) then return end
 		if not rgmCanTool(ent, pl) then return end
 
+		local posLocks = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmPosLocks[ent]) or {}
+		local angLocks = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmAngLocks[ent]) or {}
+
 		local defaultPose = rgm.GetDefaultPhysPose(ent)
 		local function resetAll(bon)
 			local p = rgm.BoneToPhysBone(ent, bon)
-			if p then
+			if p and (not posLocks[p] or not angLocks[p]) then
 				local offset = defaultPose[p]
 				local po = ent:GetPhysicsObjectNum(p)
 				local ppos, pang
@@ -1676,8 +1679,12 @@ local NETFUNC = {
 				local pos, ang = LocalToWorld(offset.pos, offset.ang, ppos, pang)
 				po:EnableMotion(true)
 				po:Wake()
-				po:SetPos(pos)
-				po:SetAngles(ang)
+				if not posLocks[p] then
+					po:SetPos(pos)
+				end
+				if not angLocks[p] then
+					po:SetAngles(ang)
+				end
 				po:EnableMotion(false)
 				po:Wake()
 			else
@@ -1715,10 +1722,12 @@ local NETFUNC = {
 		if not IsValid(ent) then return end
 		if not rgmCanTool(ent, pl) then return end
 
+		local lockTable = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmPosLocks[ent]) or {}
+
 		local defaultPose = rgm.GetDefaultPhysPose(ent)
 		local function resetPos(bon)
 			local p = rgm.BoneToPhysBone(ent, bon)
-			if p then
+			if p and not lockTable[p] then
 				local offset = defaultPose[p]
 				local po = ent:GetPhysicsObjectNum(p)
 				local ppos, pang
@@ -1764,10 +1773,12 @@ local NETFUNC = {
 
 		if not rgmCanTool(ent, pl) then return end
 
+		local lockTable = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmAngLocks[ent]) or {}
+
 		local defaultPose = rgm.GetDefaultPhysPose(ent)
 		local function resetAng(bon)
 			local p = rgm.BoneToPhysBone(ent, bon)
-			if p then
+			if p and not lockTable[p] then
 				local offset = defaultPose[p]
 				local po = ent:GetPhysicsObjectNum(p)
 				local ppos, pang

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1648,8 +1648,27 @@ local NETFUNC = {
 		if not IsValid(ent) then return end
 		if not rgmCanTool(ent, pl) then return end
 
-		if children then
-			RecursiveBoneFunc(bone, ent, function(bon)
+		local defaultPose = rgm.GetDefaultPhysPose(ent)
+		local function resetAll(bon)
+			local p = rgm.BoneToPhysBone(ent, bon)
+			if p then
+				local offset = defaultPose[p]
+				local po = ent:GetPhysicsObjectNum(p)
+				local ppos, pang
+				if offset.parent then
+					local ppo = ent:GetPhysicsObjectNum(offset.parent)
+					ppos, pang = ppo:GetPos(), ppo:GetAngles()
+				else
+					ppos, pang = ent:GetPos(), ent:GetAngles()
+				end
+				local pos, ang = LocalToWorld(offset.pos, offset.ang, ppos, pang)
+				po:EnableMotion(true)
+				po:Wake()
+				po:SetPos(pos)
+				po:SetAngles(ang)
+				po:EnableMotion(false)
+				po:Wake()
+			else
 				local pos, ang, scale = ent:GetManipulateBonePosition(bon), ent:GetManipulateBoneAngles(bon), ent:GetManipulateBoneScale(bon)
 				pos:Set(vector_origin)
 				ang:Set(angle_zero)
@@ -1658,16 +1677,13 @@ local NETFUNC = {
 				ent:ManipulateBonePosition(bon, pos)
 				ent:ManipulateBoneAngles(bon, ang)
 				ent:ManipulateBoneScale(bon, scale)
-			end)
-		else
-			local pos, ang, scale = ent:GetManipulateBonePosition(bone), ent:GetManipulateBoneAngles(bone), ent:GetManipulateBoneScale(bone)
-			pos:Set(vector_origin)
-			ang:Set(angle_zero)
-			scale:Set(VECTOR_SCALEDEF)
+			end
+		end
 
-			ent:ManipulateBonePosition(bone, pos)
-			ent:ManipulateBoneAngles(bone, ang)
-			ent:ManipulateBoneScale(bone, scale)
+		if children then
+			RecursiveBoneFunc(bone, ent, resetAll)
+		else
+			resetAll(bone)
 		end
 
 		NetStarter.rgmUpdateSliders()
@@ -1687,18 +1703,37 @@ local NETFUNC = {
 		if not IsValid(ent) then return end
 		if not rgmCanTool(ent, pl) then return end
 
-		if children then
-			RecursiveBoneFunc(bone, ent, function(bon)
+		local defaultPose = rgm.GetDefaultPhysPose(ent)
+		local function resetPos(bon)
+			local p = rgm.BoneToPhysBone(ent, bon)
+			if p then
+				local offset = defaultPose[p]
+				local po = ent:GetPhysicsObjectNum(p)
+				local ppos, pang
+				if offset.parent then
+					local ppo = ent:GetPhysicsObjectNum(offset.parent)
+					ppos, pang = ppo:GetPos(), ppo:GetAngles()
+				else
+					ppos, pang = ent:GetPos(), ent:GetAngles()
+				end
+				local pos = LocalToWorld(offset.pos, offset.ang, ppos, pang)
+				po:EnableMotion(true)
+				po:Wake()
+				po:SetPos(pos)
+				po:EnableMotion(false)
+				po:Wake()
+			else
 				local pos = ent:GetManipulateBonePosition(bon)
 				pos:Set(vector_origin)
 
 				ent:ManipulateBonePosition(bon, pos)
-			end)
-		else
-			local pos = ent:GetManipulateBonePosition(bone)
-			pos:Set(vector_origin)
+			end
+		end
 
-			ent:ManipulateBonePosition(bone, pos)
+		if children then
+			RecursiveBoneFunc(bone, ent, resetPos)
+		else
+			resetPos(bone)
 		end
 
 		NetStarter.rgmUpdateSliders()
@@ -1717,18 +1752,37 @@ local NETFUNC = {
 
 		if not rgmCanTool(ent, pl) then return end
 
-		if children then
-			RecursiveBoneFunc(bone, ent, function(bon)
+		local defaultPose = rgm.GetDefaultPhysPose(ent)
+		local function resetAng(bon)
+			local p = rgm.BoneToPhysBone(ent, bon)
+			if p then
+				local offset = defaultPose[p]
+				local po = ent:GetPhysicsObjectNum(p)
+				local ppos, pang
+				if offset.parent then
+					local ppo = ent:GetPhysicsObjectNum(offset.parent)
+					ppos, pang = ppo:GetPos(), ppo:GetAngles()
+				else
+					ppos, pang = ent:GetPos(), ent:GetAngles()
+				end
+				local _, ang = LocalToWorld(offset.pos, offset.ang, ppos, pang)
+				po:EnableMotion(true)
+				po:Wake()
+				po:SetAngles(ang)
+				po:EnableMotion(false)
+				po:Wake()
+			else
 				local ang = ent:GetManipulateBoneAngles(bon)
 				ang:Set(angle_zero)
 
 				ent:ManipulateBoneAngles(bon, ang)
-			end)
-		else
-			local ang = ent:GetManipulateBoneAngles(bone)
-			ang:Set(angle_zero)
+			end
+		end
 
-			ent:ManipulateBoneAngles(bone, ang)
+		if children then
+			RecursiveBoneFunc(bone, ent, resetAng)
+		else
+			resetAng(bone)
 		end
 
 		NetStarter.rgmUpdateSliders()
@@ -1747,18 +1801,17 @@ local NETFUNC = {
 
 		if not rgmCanTool(ent, pl) then return end
 
-		if children then
-			RecursiveBoneFunc(bone, ent, function(bon)
-				local scale = ent:GetManipulateBoneScale(bon)
-				scale:Set(VECTOR_SCALEDEF)
-
-				ent:ManipulateBoneScale(bon, scale)
-			end)
-		else
-			local scale = ent:GetManipulateBoneScale(bone)
+		local function resetScale(bon)
+			local scale = ent:GetManipulateBoneScale(bon)
 			scale:Set(VECTOR_SCALEDEF)
 
-			ent:ManipulateBoneScale(bone, scale)
+			ent:ManipulateBoneScale(bon, scale)
+		end
+
+		if children then
+			RecursiveBoneFunc(bone, ent, resetScale)
+		else
+			resetScale(bone)
 		end
 
 		NetStarter.rgmUpdateSliders()
@@ -1777,18 +1830,17 @@ local NETFUNC = {
 
 		if not rgmCanTool(ent, pl) then return end
 
-		if children then
-			RecursiveBoneFunc(bone, ent, function(bon)
-				local scale = ent:GetManipulateBoneScale(bon)
-				scale:Set(VECTOR_NEARZERO)
-
-				ent:ManipulateBoneScale(bon, scale)
-			end)
-		else
-			local scale = ent:GetManipulateBoneScale(bone)
+		local function resetScale(bon)
+			local scale = ent:GetManipulateBoneScale(bon)
 			scale:Set(VECTOR_NEARZERO)
 
-			ent:ManipulateBoneScale(bone, scale)
+			ent:ManipulateBoneScale(bon, scale)
+		end
+
+		if children then
+			RecursiveBoneFunc(bone, ent, resetScale)
+		else
+			resetScale(bone)
 		end
 
 		NetStarter.rgmUpdateSliders()

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -21,6 +21,7 @@ TOOL.ClientConVar["drawskeleton"] = 0
 TOOL.ClientConVar["snapenable"] = 0
 TOOL.ClientConVar["snapamount"] = 30
 TOOL.ClientConVar["drawsphere"] = 0
+TOOL.ClientConVar["resetphys"] = 1
 
 TOOL.ClientConVar["ik_leg_L"] = 0
 TOOL.ClientConVar["ik_leg_R"] = 0
@@ -1662,11 +1663,12 @@ local NETFUNC = {
 
 		local posLocks = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmPosLocks[ent]) or {}
 		local angLocks = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmAngLocks[ent]) or {}
+		local resetPhys = tobool(pl:GetInfo("ragdollmover_resetphys"))
 
 		local defaultPose = rgm.GetDefaultPhysPose(ent)
 		local function resetAll(bon)
 			local p = rgm.BoneToPhysBone(ent, bon)
-			if p and (not posLocks[p] or not angLocks[p]) then
+			if resetPhys and p and (not posLocks[p] or not angLocks[p]) then
 				local offset = defaultPose[p]
 				local po = ent:GetPhysicsObjectNum(p)
 				local ppos, pang
@@ -1722,12 +1724,13 @@ local NETFUNC = {
 		if not IsValid(ent) then return end
 		if not rgmCanTool(ent, pl) then return end
 
+		local resetPhys = tobool(pl:GetInfo("ragdollmover_resetphys"))
 		local lockTable = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmPosLocks[ent]) or {}
 
 		local defaultPose = rgm.GetDefaultPhysPose(ent)
 		local function resetPos(bon)
 			local p = rgm.BoneToPhysBone(ent, bon)
-			if p and not lockTable[p] then
+			if resetPhys and p and not lockTable[p] then
 				local offset = defaultPose[p]
 				local po = ent:GetPhysicsObjectNum(p)
 				local ppos, pang
@@ -1774,13 +1777,14 @@ local NETFUNC = {
 		if not rgmCanTool(ent, pl) then return end
 
 		local lockTable = (RAGDOLLMOVER[pl] and RAGDOLLMOVER[pl].rgmPosLocks and RAGDOLLMOVER[pl].rgmAngLocks[ent]) or {}
+		local resetPhys = tobool(pl:GetInfo("ragdollmover_resetphys"))
 
 		local defaultPose = rgm.GetDefaultPhysPose(ent)
 		local function resetAng(bon)
 			local p = rgm.BoneToPhysBone(ent, bon)
 			-- Only reset angles if we are a child of a bone, i.e. we're not a root bone
 			-- Same logic applies for `rgmResetAll`
-			if p and not lockTable[p] and rgm.GetPhysBoneParent(ent, p) then
+			if resetPhys and p and not lockTable[p] and rgm.GetPhysBoneParent(ent, p) then
 				local offset = defaultPose[p]
 				local po = ent:GetPhysicsObjectNum(p)
 				local ppos, pang
@@ -4860,6 +4864,8 @@ function TOOL.BuildCPanel(CPanel)
 
 		local physmovecheck = CCheckBox(Col4, "#tool.ragdollmover.physmove", "ragdollmover_physmove")
 		physmovecheck:SetToolTip("#tool.ragdollmover.physmovetip")
+		local resetphyscheck = CCheckBox(Col4, "#tool.ragdollmover.resetphys", "ragdollmover_resetphys")
+		resetphyscheck:SetToolTip("#tool.ragdollmover.resetphystip")
 		RGMMakeAngleSnap(Col4)
 		RGMMakeResetLocksPanel(Col4) 
 		

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -1682,7 +1682,7 @@ local NETFUNC = {
 				if not posLocks[p] then
 					po:SetPos(pos)
 				end
-				if not angLocks[p] then
+				if not angLocks[p] and rgm.GetPhysBoneParent(ent, p) then
 					po:SetAngles(ang)
 				end
 				po:EnableMotion(false)
@@ -1778,7 +1778,9 @@ local NETFUNC = {
 		local defaultPose = rgm.GetDefaultPhysPose(ent)
 		local function resetAng(bon)
 			local p = rgm.BoneToPhysBone(ent, bon)
-			if p and not lockTable[p] then
+			-- Only reset angles if we are a child of a bone, i.e. we're not a root bone
+			-- Same logic applies for `rgmResetAll`
+			if p and not lockTable[p] and rgm.GetPhysBoneParent(ent, p) then
 				local offset = defaultPose[p]
 				local po = ent:GetPhysicsObjectNum(p)
 				local ppos, pang

--- a/lua/weapons/gmod_tool/stools/ragdollmover.lua
+++ b/lua/weapons/gmod_tool/stools/ragdollmover.lua
@@ -3212,6 +3212,15 @@ local function CManipSlider(cpanel, text, mode, axis, min, max, dec, textentry)
 
 	return slider
 end
+local function RGMResetCurBone(mode)
+	mode = mode or 0
+	if not RAGDOLLMOVER[pl] or not RAGDOLLMOVER[pl].Entity then return end
+	local ent, id = RAGDOLLMOVER[pl].Entity, RAGDOLLMOVER[pl].Bone
+
+	if not IsValid(ent) then return end
+	if mode == 3 then ClientBoneState:SetBoneScale(id, VECTOR_SCALEDEF) end
+	NodeFunctions[1 + mode](ent, id)
+end
 local function CManipEntry(cpanel, mode)
 	local parent = vgui.Create("Panel", cpanel)
 	parent:SetTall(20)
@@ -3261,12 +3270,7 @@ local function CManipEntry(cpanel, mode)
 	butt:SetText("#tool.ragdollmover.resetmenu")
 
 	butt.DoClick = function()
-		if not RAGDOLLMOVER[pl] or not RAGDOLLMOVER[pl].Entity then return end
-		local ent, id = RAGDOLLMOVER[pl].Entity, RAGDOLLMOVER[pl].Bone
-
-		if not IsValid(ent) then return end
-		if mode == 3 then ClientBoneState:SetBoneScale(id, VECTOR_SCALEDEF) end
-		NodeFunctions[1 + mode](ent, id)
+		RGMResetCurBone(mode)
 	end
 
 	parent.PerformLayout = function(self)
@@ -3467,15 +3471,6 @@ local function RGMResetAllBones()
 	NetStarter.rgmResetAllBones()
 		net.WriteEntity(RAGDOLLMOVER[pl].Entity)
 	net.SendToServer()
-end
-
-local function RGMResetCurBone()
-	if not RAGDOLLMOVER[pl] or not RAGDOLLMOVER[pl].Entity then return end
-	local ent, id = RAGDOLLMOVER[pl].Entity, RAGDOLLMOVER[pl].Bone
-
-	if not IsValid(ent) then return end
-	ClientBoneState:SetBoneScale(id, VECTOR_SCALEDEF)
-	NodeFunctions[1](ent, id)
 end
 
 local function AddHBar(self) -- There is no horizontal scrollbars in gmod, so I guess we'll override vertical one from GMod - I think this is incorrect now, but I'll keep it

--- a/resource/localization/en/ragdollmover_tools.properties
+++ b/resource/localization/en/ragdollmover_tools.properties
@@ -80,6 +80,8 @@ tool.ragdollmover.scalechildren=Scale children bones
 tool.ragdollmover.smovechildren=Move children bones when scaling
 tool.ragdollmover.physmove=Nonphysical bones move physical bones
 tool.ragdollmover.physmovetip=Manipulating nonphysical bones with gizmos will also move physical children bones of it, for best results use Ragdoll Stretch and Ragdoll Weight tools from workshop
+tool.ragdollmover.resetphys=Reset physical bones
+tool.ragdollmover.resetphystip=Physical bones will reset to reference pose relative to their parent physical bone
 tool.ragdollmover.scalerelativemove=Relative child bone scaling
 
 tool.ragdollmover.resetmenu=Reset


### PR DESCRIPTION
- Resolves https://github.com/Winded/RagdollMover/issues/96
- Interfaces with the commit that addresses https://github.com/Winded/RagdollMover/issues/108; reset buttons will also reset physical bone transforms, if one of their transforms are unlocked and `ragdollmover_resetphys 1`